### PR TITLE
recorrect sysnet-app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ requires-python = ">=3.7"
 urls = {Repository = "https://github.com/mehdirezaie/sysnetdev"}
 classifiers = ["Programming Language :: Python :: 3"]
 
+[project.scripts]
+sysnet-app = "sysnet.__main__:main"
+
 [tool.setuptools]
 packages = ["sysnet", "sysnet.sources"]
-script-files = ["scripts/sysnet-app"]

--- a/scripts/app.py
+++ b/scripts/app.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+""" 
+    A high-level code for running the SYSNet software
+
+    Take a look into the config file under the directory 'scripts'
+    to learn about the input parameters.
+    
+    Mehdi Rezaie, mr095415@ohio.edu
+    October 2020
+"""
+import sysnet
+
+debug = False
+if debug:
+    sysnet.detect_anomaly() # this will slow down
+
+config = sysnet.parse_cmd_arguments('config.yaml')
+pipeline = sysnet.SYSNet(config)
+pipeline.run()

--- a/sysnet/__main__.py
+++ b/sysnet/__main__.py
@@ -8,17 +8,24 @@
     Mehdi Rezaie, mr095415@ohio.edu
     October 2020
 """
-def main(debug=False, args=None):
-    import argparse
+def main(debug=False):
+    import sys
     import sysnet
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('config_fn', action='store', type=str, help='Name of configuration file')
-    args = parser.parse_args(args=args)
+    
+    try:
+        yaml_config = sys.argv[1].lower()
+    except IndexError:  # no command
+        print("Pass config file or command line arguments")
+        exit()
+    if yaml_config.startswith('-'):  # not a config file, but an argparse argument
+        yaml_config = None
+    else:
+        sys.argv.pop(1)
 
     if debug:
         sysnet.detect_anomaly() # this will slow down
 
-    config = sysnet.parse_cmd_arguments(args.config_fn)
+    config = sysnet.parse_cmd_arguments(yaml_config=yaml_config)
     pipeline = sysnet.SYSNet(config)
     pipeline.run()
 

--- a/sysnet/cli.py
+++ b/sysnet/cli.py
@@ -11,12 +11,12 @@ def parse_cmd_arguments(yaml_config=None):
     ap.add_argument('-i', '--input_path',
                         type=str,
                         nargs='*',
-                        default=cf.fetch('input_path', '../input/eBOSS.ELG.NGC.DR7.table.fits'),
+                        default=cf.fetch('input_path', './input/eBOSS.ELG.NGC.DR7.table.fits'),
                         help='path to the input data')
 
     ap.add_argument('-o', '--output_path',
                         type=str,
-                        default=cf.fetch('output_path', '../output/model_test'),
+                        default=cf.fetch('output_path', './output/model_test'),
                         help='path to the output')
 
     ap.add_argument('--restore_model',


### PR DESCRIPTION
I misunderstood the script sysnet-app... an argparse is already called in `parse_cmd_arguments`. So I have just reset the original scripts/app.py, and added a `__main__.py` in sysnet/ which contains the actual new sysnet-app entry point (the previous scripts solution is deprecated anyway).